### PR TITLE
Add pure version of getSplitRows

### DIFF
--- a/library/Data/NBA/Stats.hs
+++ b/library/Data/NBA/Stats.hs
@@ -277,7 +277,7 @@ get path params =
     >>= MonadHttp.performRequest
     where
       modifyRequest =
-        HTTP.setRequestHeaders [("Accept-Language","en-us"), ("Accept", "application/json"), ("Referer", "stats.nba.com")]
+        HTTP.setRequestHeaders [("Accept-Language","en-us"), ("Accept", "application/json")]
         . HTTP.setQueryString params
 
 {- $use


### PR DESCRIPTION
My first Haskell PR, this code is probably ugly, don't judge :smile:

I only pure-ified `getSplitRows` because I don't really understand what `getSplitRow` does. Let me know what you think/how this could be improved.